### PR TITLE
Point to archived version of glibc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIONIC_DIR = https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage/+build/15772577/+files
-LIBC_DIR = http://http.us.debian.org/debian/pool/main/g/glibc
+LIBC_DIR = https://snapshot.debian.org/archive/debian/20181229T221753Z/pool/main/g/glibc
 
 CHROMIUM_BROWSER = chromium-browser_71.0.3578.98-0ubuntu0.18.04.1_armhf.deb
 CHROMIUM_CODECS = chromium-codecs-ffmpeg-extra_71.0.3578.98-0ubuntu0.18.04.1_armhf.deb


### PR DESCRIPTION
Hi! 👋 

First of all, thanks for making this!

I tried installing it today, but the glibc artifact has moved on to another life (💀), and replaced with `libc6_2.28-5_armhf.deb`. So, let's point to the Debian archive, and we'll always have access to the version we want!

(Unless you know of a way to find the latest iteration of `libc6_2.28-x`!)

Fixes #1.