### PR TITLE
Update to Chromium 75 and revise README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-BIONIC_DIR = https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage/+build/16422997/+files
+BIONIC_DIR = https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage/+build/17277616/+files
 LIBC_DIR = https://snapshot.debian.org/archive/debian/20190701T031013Z/pool/main/g/glibc
 
-CHROMIUM_BROWSER = chromium-browser_72.0.3626.119-0ubuntu0.18.04.1_armhf.deb
-CHROMIUM_CODECS = chromium-codecs-ffmpeg-extra_72.0.3626.119-0ubuntu0.18.04.1_armhf.deb
+CHROMIUM_BROWSER = chromium-browser_75.0.3770.142-0ubuntu0.18.04.1_armhf.deb
+CHROMIUM_CODECS = chromium-codecs-ffmpeg-extra_75.0.3770.142-0ubuntu0.18.04.1_armhf.deb
 LIBC = libc6_2.28-10_armhf.deb
 RASPBIAN_CHROMIUM_BROWSER = $(subst _armhf,+rpi1_armhf,$(CHROMIUM_BROWSER))
 RASPBIAN_CHROMIUM_CODECS = $(subst _armhf,+rpi1_armhf,$(CHROMIUM_CODECS))
@@ -13,13 +13,13 @@ all: $(RASPBIAN_CHROMIUM_BROWSER) $(RASPBIAN_CHROMIUM_CODECS)
 	@echo "    $(RASPBIAN_CHROMIUM_CODECS)"
 
 $(LIBC):
-	wget $(LIBC_DIR)/$(LIBC)
+	curl -O -L $(LIBC_DIR)/$(LIBC)
 
 $(CHROMIUM_BROWSER):
-	wget $(BIONIC_DIR)/$(CHROMIUM_BROWSER)
+	curl -O -L $(BIONIC_DIR)/$(CHROMIUM_BROWSER)
 
 $(CHROMIUM_CODECS):
-	wget $(BIONIC_DIR)/$(CHROMIUM_CODECS)
+	curl -O -L $(BIONIC_DIR)/$(CHROMIUM_CODECS)
 
 # Downgrade libc dependency to 2.24, tag with +rpi1 suffix
 $(RASPBIAN_CHROMIUM_CODECS): $(CHROMIUM_CODECS)

--- a/README.md
+++ b/README.md
@@ -16,4 +16,13 @@ Then try it out:
 
     chromium-browser --version
 
-and it should say something like `Chromium 71.0.3578.98 Built on Ubuntu , running on Raspbian 9.6`
+and it should say something like `Chromium 75.0.3770.142 Built on Ubuntu , running on Raspbian 9.6`
+
+On Raspbian Buster they're back to keeping Chromium current so this
+becomes less relevant, unless they happen to fall behind again.
+
+To update this repo anytime there's a new version of Chromium
+it's not that hard. Go to
+https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage
+and click around to find links to the two relevant \*.deb files, then
+update paths accordingly in `Makefile`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ becomes less relevant, unless they happen to fall behind again.
 
 To update this repo anytime there's a new version of Chromium
 it's not that hard. Go to
-https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage
-and click around to find links to the two relevant \*.deb files, then
-update paths accordingly in `Makefile`. Please file a pull request
-with your changes so that everyone can benefit.
+https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage/+packages
+and click through to find links to the two relevant 18.04 armhf
+\*.deb files, then update paths accordingly in `Makefile`. Please
+file a pull request with your changes so that everyone can benefit.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ On your Raspbian Stretch system, install the repackaged Chromium:
 
     sudo dpkg --install chromium*rpi1_armhf.deb
 
+If you get any package version conflicts with `chromium-browser-l10n`
+and are fine all-English, remove the l10n package:
+
+    sudo apt remove chromium-browser-l10n
+
 Then try it out:
 
     chromium-browser --version

--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ To update this repo anytime there's a new version of Chromium
 it's not that hard. Go to
 https://launchpad.net/~canonical-chromium-builds/+archive/ubuntu/stage
 and click around to find links to the two relevant \*.deb files, then
-update paths accordingly in `Makefile`.
+update paths accordingly in `Makefile`. Please file a pull request
+with your changes so that everyone can benefit.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Chromium on Debian armhf appears to have been broken starting with version 68.
-Yet it works fine on Ubuntu 18.04 Bionic armhf.
+Chromium on Debian Stretch armhf appears to have been broken starting
+with version 68. Yet it works fine on Ubuntu 18.04 Bionic armhf.
 
 So let's take the Ubuntu binary and tweak its dependencies to install smoothly on
 Raspbian. Clone this repo on a PC or Pi then run like so:


### PR DESCRIPTION
This branch:
* Updates the links for Chromium 75
* Uses `curl` instead of `wget` so macOS users have no requirement to `brew install wget`
* Updates README to be current now that Raspbian Buster is out